### PR TITLE
Add config setting for allowed organisations and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# CARE Doctor Connect
+
+A federated micro-frontend plugin for [CARE](https://github.com/ohcnetwork/care_fe) that adds a **Doctor Connect** sheet to the patient encounter view, letting clinical staff quickly browse a facility's organization tree and reach the right doctor (or any other role) on call.
+
+## Features
+
+- Adds a `Doctor Connect` quick action to the Patient Info Card on the encounter page.
+- Renders the facility's organization tree as collapsible sections.
+- Shows users assigned to each organization with their role and contact details.
+- Filters users by role via an autocomplete (defaults to `Doctor` when available).
+- Plugin-config driven filtering of which organizations and which roles appear (set per deployment from CARE's admin panel).
+
+## Configuration
+
+The plugin reads runtime configuration from the `meta` object of its `PlugConfig` in CARE core (managed under **Admin → Apps** in the CARE admin panel). Configuration is delivered to the plugin via the `__meta` prop injected by CARE's `PLUGIN_Component`.
+
+### Supported keys
+
+| Key                              | Type       | Description                                                                                                                             |
+| -------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowed_facility_organizations` | `string[]` | Names of top-level facility organizations to show in the sheet. Matched case-insensitively against `organization.name`. Omit/empty = show all. |
+| `allowed_filter_roles`           | `string[]` | Names of roles to expose in the role-filter autocomplete. Matched case-insensitively against `role.name`. Omit/empty = show all roles.  |
+
+### Example
+
+In CARE admin, set the plugin's `meta` JSON to:
+
+```json
+{
+  "url": "https://doctor-connect.example.org/assets/manifest.js",
+  "name": "care_doctor_connect_fe",
+  "allowed_facility_organizations": ["Health Department"],
+  "allowed_filter_roles": ["Doctor", "Nurse"]
+}
+```
+
+With this config:
+
+- Only the top-level facility organization named `Health Department` (case-insensitive) appears in the sheet. Others (e.g. `Administration`) are filtered out.
+- The role filter autocomplete only offers `Doctor` and `Nurse`.
+
+If a key is missing or its array is empty, no filtering is applied for that dimension (full backwards-compatible behavior).
+
+> Note: `allowed_facility_organizations` filters **facility organizations** (the org tree shown inside the sheet) by name. `allowed_filter_roles` filters the **Role** catalog used by the autocomplete. These are independent — you can set either, both, or neither.
+
+## Development
+
+### Prerequisites
+
+- Node.js 22+
+- A running CARE backend and CARE frontend (see [care_fe](https://github.com/ohcnetwork/care_fe))
+
+### Setup
+
+```bash
+npm install
+npm run start    # builds in watch mode and serves on http://localhost:6173
+```
+
+Then in your local CARE frontend `.env`, register this plugin's manifest URL via `REACT_ENABLED_APPS` (or via the admin Apps page) pointing to `http://localhost:6173/assets/manifest.js`.
+
+### Build
+
+```bash
+npm run build
+```
+
+The federated build is emitted to `dist/`.

--- a/src/components/DoctorConnectSheet/index.tsx
+++ b/src/components/DoctorConnectSheet/index.tsx
@@ -30,8 +30,8 @@ export default function DoctorConnectSheet({
   className,
   __meta,
 }: DoctorConnectSheetProps) {
-  const allowedOrganizations = __meta?.allowed_organizations;
-  const allowedRoles = __meta?.allowed_roles;
+  const allowedOrganizations = __meta?.allowed_facility_organizations;
+  const allowedRoles = __meta?.allowed_filter_roles;
   const { t } = useTranslation(I18NNAMESPACE);
 
   const [roleSearch, setRoleSearch] = useState("");

--- a/src/components/DoctorConnectSheet/index.tsx
+++ b/src/components/DoctorConnectSheet/index.tsx
@@ -6,12 +6,12 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import Autocomplete from "@/components/ui/autocomplete";
 import { Button } from "@/components/ui/button";
 import { I18NNAMESPACE } from "@/lib/constants";
-import { Loader2, HeadsetIcon } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import OrganizationCollapsible from "./OrganizationCollapsible";
 import { PatientInfoCardQuickActionsProps } from "@/components/pluggables/PatientInfoCardQuickActions";
 import type { Role } from "@/types/role";
@@ -28,7 +28,10 @@ export type Filters = {
 export default function DoctorConnectSheet({
   encounter,
   className,
+  __meta,
 }: DoctorConnectSheetProps) {
+  const allowedOrganizations = __meta?.allowed_organizations;
+  const allowedRoles = __meta?.allowed_roles;
   const { t } = useTranslation(I18NNAMESPACE);
 
   const [roleSearch, setRoleSearch] = useState("");
@@ -39,22 +42,41 @@ export default function DoctorConnectSheet({
     queryFn: () => apis.roles.list({ name: roleSearch?.trim() ?? undefined }),
   });
 
+  const filteredRoles = useMemo(() => {
+    if (!roles?.results) return [];
+    if (!Array.isArray(allowedRoles) || allowedRoles.length === 0) {
+      return roles.results;
+    }
+    const allowed = allowedRoles.map((name) => name.toLowerCase());
+    return roles.results.filter((role) =>
+      allowed.includes(role.name.toLowerCase())
+    );
+  }, [roles, allowedRoles]);
+
   const filters: Filters = { role: selectedRole?.id ?? "" };
 
   useEffect(() => {
-    const doctorRole = roles?.results.find(
+    const doctorRole = filteredRoles.find(
       (role) => role.name.toLowerCase() === "doctor"
     );
 
     if (doctorRole && !selectedRole) {
       setSelectedRole(doctorRole);
+    } else if (
+      !doctorRole &&
+      !selectedRole &&
+      filteredRoles.length > 0 &&
+      Array.isArray(allowedRoles) &&
+      allowedRoles.length > 0
+    ) {
+      setSelectedRole(filteredRoles[0]);
     }
-  }, [roles, selectedRole]);
+  }, [filteredRoles, selectedRole, allowedRoles]);
 
   const roleOptions =
     [
       selectedRole,
-      ...(roles?.results.filter((role) => role.id !== selectedRole?.id) ?? []),
+      ...filteredRoles.filter((role) => role.id !== selectedRole?.id),
     ]
       .filter(Boolean)
       .map((role) => ({
@@ -128,6 +150,18 @@ export default function DoctorConnectSheet({
           ) : (
             organizations?.results
               ?.filter((organization) => organization.level_cache === 0)
+              .filter((organization) => {
+                if (
+                  !Array.isArray(allowedOrganizations) ||
+                  allowedOrganizations.length === 0
+                ) {
+                  return true;
+                }
+                const allowed = allowedOrganizations.map((name) =>
+                  name.toLowerCase()
+                );
+                return allowed.includes(organization.name.toLowerCase());
+              })
               .map((organization) => (
                 <OrganizationCollapsible
                   key={organization.id}

--- a/src/components/DoctorConnectSheet/index.tsx
+++ b/src/components/DoctorConnectSheet/index.tsx
@@ -30,8 +30,8 @@ export default function DoctorConnectSheet({
   className,
   __meta,
 }: DoctorConnectSheetProps) {
-  const allowedOrganizations = __meta?.allowed_facility_organizations;
-  const allowedRoles = __meta?.allowed_filter_roles;
+  const allowedOrganizations = __meta?.config?.allowed_facility_organizations;
+  const allowedRoles = __meta?.config?.allowed_filter_roles;
   const { t } = useTranslation(I18NNAMESPACE);
 
   const [roleSearch, setRoleSearch] = useState("");

--- a/src/components/pluggables/PatientInfoCardQuickActions.tsx
+++ b/src/components/pluggables/PatientInfoCardQuickActions.tsx
@@ -6,8 +6,12 @@ export type PatientInfoCardQuickActionsProps = {
   encounter: Encounter;
   className?: string;
   __meta?: {
-    allowed_facility_organizations?: string[];
-    allowed_filter_roles?: string[];
+    url?: string;
+    name?: string;
+    config?: {
+      allowed_facility_organizations?: string[];
+      allowed_filter_roles?: string[];
+    };
     [key: string]: unknown;
   };
 };

--- a/src/components/pluggables/PatientInfoCardQuickActions.tsx
+++ b/src/components/pluggables/PatientInfoCardQuickActions.tsx
@@ -5,6 +5,11 @@ import DoctorConnectSheet from "@/components/DoctorConnectSheet";
 export type PatientInfoCardQuickActionsProps = {
   encounter: Encounter;
   className?: string;
+  __meta?: {
+    allowed_organizations?: string[];
+    allowed_roles?: string[];
+    [key: string]: unknown;
+  };
 };
 
 const PatientInfoCardQuickActions: FC<PatientInfoCardQuickActionsProps> = (

--- a/src/components/pluggables/PatientInfoCardQuickActions.tsx
+++ b/src/components/pluggables/PatientInfoCardQuickActions.tsx
@@ -6,8 +6,8 @@ export type PatientInfoCardQuickActionsProps = {
   encounter: Encounter;
   className?: string;
   __meta?: {
-    allowed_organizations?: string[];
-    allowed_roles?: string[];
+    allowed_facility_organizations?: string[];
+    allowed_filter_roles?: string[];
     [key: string]: unknown;
   };
 };


### PR DESCRIPTION
You can now set 

```
config : {
  "allowed_facility_organizations": ["doctor", "nurse"],
  "allowed_filter_roles": ["Doctor", "Nurse"]
}
```

PR for apps registry : https://github.com/ohcnetwork/care_apps_registry/pull/15

in the care app config to only show certain organisations and roles